### PR TITLE
[Fix] BUG: Exception not handled successfully

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,15 +5,14 @@ int simulator_verbose_output = 0;
 
 int main(int argc, char **argv) {
     ArgumentParser parser("Argument parser");
-    parser.add_argument("-t", "Program trace file");
-    parser.add_argument("-c", "Cache config file");
+    parser.add_argument("-t", "Program trace file", true);
+    parser.add_argument("-c", "Cache config file", true);
     parser.add_argument("-v", "--verbose", "Verbose output", false);
 
-    // BUG: Exception not handled successfully
     try {
         parser.parse(argc, argv);
     } catch (const ArgumentParser::ArgumentNotFound &ex) {
-        //std::cerr << ex.what() << std::endl;
+        std::cerr << ex.what() << std::endl;
         parser.print_help();
         return -1;
     }


### PR DESCRIPTION
Since in `ArgumentParser::add_argument`, `required` is `false` by default.

```cpp
void add_argument(const std::string &name, 
                  const std::string &desc, 
                  const bool required = false)
```